### PR TITLE
Example with Compojure support

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -18,6 +18,8 @@
                             [selmer                "RELEASE"]
                             ;; used to demonstrate Component-based FW/1 lifecycle
                             [com.stuartsierra/component "RELEASE" :scope "test"]
+                            ;; used to demonstrate Compojure routing with FW/1
+                            [compojure "RELEASE" :scope "test"]
                             [seancorfield/boot-expectations "RELEASE" :scope "test"]])
 
 (require '[seancorfield.boot-expectations :refer [expectations]])

--- a/examples/usermanager/controllers/user.clj
+++ b/examples/usermanager/controllers/user.clj
@@ -36,5 +36,6 @@
 (defn save [rc]
   (swap! changes inc)
   (let [{:keys [id first-name last-name email department-id]} rc]
-    (save-user {:id (to-long id) :first-name first-name :last-name last-name :email email :department-id (to-long department-id)}))
+    (save-user {:id (to-long id) :first-name first-name :last-name last-name
+                :email email :department-id (to-long department-id)}))
   (redirect rc "/user/list"))


### PR DESCRIPTION
This refactors FW/1 to be able to work more easily with Compojure. It builds on the Component-based example. Fixes #21 by side-stepping the extract-as-library question and embracing Compojure instead.
